### PR TITLE
Feature/7 onerror event

### DIFF
--- a/src/EventSourceSharp/EventSourceClient.cs
+++ b/src/EventSourceSharp/EventSourceClient.cs
@@ -153,7 +153,7 @@ public class EventSourceClient : IEventSourceClient
                     break;
                 case "data":
                     dataBuffer.Append(value);
-                    dataBuffer.Append("\n");
+                    dataBuffer.Append('\n');
                     break;
                 case "id":
                     idBuffer = string.IsNullOrWhiteSpace(value) ? string.Empty : value;
@@ -161,7 +161,7 @@ public class EventSourceClient : IEventSourceClient
                 case "retry":
                     if (int.TryParse(value, out var retry))
                     {
-                        _retryInterval = TimeSpan.FromMilliseconds(retry >= 0 ? retry : 0);
+                        _retryInterval = TimeSpan.FromMilliseconds(Math.Max(retry, 0));
                     }
 
                     break;

--- a/src/EventSourceSharp/EventSourceClient.cs
+++ b/src/EventSourceSharp/EventSourceClient.cs
@@ -60,7 +60,7 @@ public class EventSourceClient : IEventSourceClient
                 onConnect?.Invoke();
 
                 var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
-                await ProcessEventStream(stream, cancellationToken).ConfigureAwait(false);
+                await ProcessEventStreamAsync(stream, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -74,7 +74,7 @@ public class EventSourceClient : IEventSourceClient
         }
     }
 
-    public async Task ProcessEventStream(Stream stream, CancellationToken cancellationToken)
+    public async Task ProcessEventStreamAsync(Stream stream, CancellationToken cancellationToken)
     {
         using var reader = new StreamReader(stream, Encoding.UTF8, false);
 

--- a/src/EventSourceSharp/EventSourceException.cs
+++ b/src/EventSourceSharp/EventSourceException.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace EventSourceSharp;
+
+public class EventSourceException : Exception
+{
+    public EventSourceException(string message) : base(message)
+    {
+    }
+
+    public EventSourceException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+}

--- a/src/EventSourceSharp/IEventSourceClient.cs
+++ b/src/EventSourceSharp/IEventSourceClient.cs
@@ -13,6 +13,6 @@ public interface IEventSourceClient
 
     Task ConnectAsync(Uri url);
     Task ConnectAsync(Uri url, CancellationToken cancellationToken);
-    Task ProcessEventStream(Stream stream, CancellationToken cancellationToken);
+    Task ProcessEventStreamAsync(Stream stream, CancellationToken cancellationToken);
     void Disconnect();
 }


### PR DESCRIPTION
- Adds `OnError` event
- Adds `EventSourceException` for errors
- Pushes an exception to `OnError` if `ConnectAsync` is called and the client is already running
- Renames `ProcessEventStream` to `ProcessEventStreamAsync`
- Some minor code cleanup and readability improvements